### PR TITLE
Fix: Correct Firebase initialization and summary functionality

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -10,11 +10,8 @@ const firebaseConfig = {
   measurementId: "G-8QTJS22X97"
 };
 
+// Initialize Firebase
 firebase.initializeApp(firebaseConfig);
 
 // Make Firestore available globally
 window.db = firebase.firestore();
-
-import { getFirestore } from "firebase/firestore";
-const db = getFirestore(app);
-export { db };

--- a/script.js
+++ b/script.js
@@ -1,8 +1,7 @@
 // script.js
-// Define db globally
-let db;
-firebase.initializeApp(firebaseConfig);
-db = firebase.firestore();
+
+// db is initialized in firebase-config.js and available as window.db
+// Ensure firebase-config.js is loaded before this script.
 
 function submitSummary() {
   const subject = document.getElementById("subject-select").value;
@@ -10,7 +9,7 @@ function submitSummary() {
 
   if (!summaryText.trim()) return;
 
-  db.collection("summaries").add({
+  window.db.collection("summaries").add({
     subject: subject,
     text: summaryText,
     timestamp: new Date()
@@ -25,7 +24,7 @@ function loadSummaries() {
   const list = document.getElementById("summary-list");
   list.innerHTML = "";
 
-  db.collection("summaries")
+  window.db.collection("summaries")
     .where("subject", "==", subject)
     .orderBy("timestamp", "desc")
     .get()
@@ -42,6 +41,6 @@ function loadSummaries() {
 window.addEventListener("DOMContentLoaded", () => {
   if (document.getElementById("summary-list")) {
     document.getElementById("subject-select").addEventListener("change", loadSummaries);
-    loadSummaries();
+    loadSummaries(); // Initial load
   }
 });


### PR DESCRIPTION
- Modified `firebase-config.js` to correctly initialize Firebase and establish a global `window.db` Firestore instance. Removed conflicting import/export statements.
- Updated `script.js` to use the global `window.db` instance for Firestore operations and removed redundant Firebase initializations.

These changes ensure that summaries can be saved to Firestore when you click the button on `index.html` and are correctly displayed on the `summaries.html` page.